### PR TITLE
CSA-8: Format SEIF application phone numbers with country-aware parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
-    "better-auth": "^1.2.0",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.468.0",
-    "tailwind-merge": "^2.6.0",
     "@prisma/adapter-pg": "^7.0.0",
     "@prisma/client": "^7.0.0",
     "@t3-oss/env-nextjs": "^0.12.0",
@@ -33,11 +29,16 @@
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",
+    "better-auth": "^1.2.0",
+    "clsx": "^2.1.1",
+    "libphonenumber-js": "^1.12.40",
+    "lucide-react": "^0.468.0",
     "next": "^15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
+    "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -46,17 +47,17 @@
     "@types/node": "^20.14.10",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "dotenv": "^16.4.5",
     "eslint": "^9.23.0",
     "eslint-config-next": "^15.2.3",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "dotenv": "^16.4.5",
     "prisma": "^7.0.0",
     "tailwindcss": "^4.0.15",
+    "tsx": "^4.19.2",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.27.0",
-    "tsx": "^4.19.2"
+    "typescript-eslint": "^8.27.0"
   },
   "ct3aMetadata": {
     "initVersion": "7.40.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      libphonenumber-js:
+        specifier: ^1.12.40
+        version: 1.12.40
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
@@ -2352,6 +2355,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.12.40:
+    resolution: {integrity: sha512-HKGs7GowShNls3Zh+7DTr6wYpPk5jC78l508yQQY3e8ZgJChM3A9JZghmMJZuK+5bogSfuTafpjksGSR3aMIEg==}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -5856,6 +5862,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.12.40: {}
 
   lightningcss-android-arm64@1.31.1:
     optional: true

--- a/src/app/admin/applications/[id]/page.tsx
+++ b/src/app/admin/applications/[id]/page.tsx
@@ -6,6 +6,7 @@ import { createTRPCContext } from "~/server/api/trpc";
 import { headers } from "next/headers";
 import { ApplicationDecisionPanel } from "~/components/seif/application-decision-panel";
 import { formatTorontoDateTime } from "~/lib/date";
+import { formatStoredPhoneNumber } from "~/lib/phone";
 
 export const metadata = {
   title: "Application Details",
@@ -25,12 +26,15 @@ export default async function ApplicationDetailPage({
   const { id } = await params;
   const ctx = await createTRPCContext({ headers: await headers() });
   const caller = createCaller(ctx);
-  const application = await caller.application.getById({ id }).catch(() => null);
+  const application = await caller.application
+    .getById({ id })
+    .catch(() => null);
   if (!application) notFound();
 
   const form = application.formData as Record<string, unknown>;
   const readString = (value: unknown) =>
     typeof value === "string" && value.length > 0 ? value : "—";
+  const readPhone = (value: unknown) => formatStoredPhoneNumber(value) ?? "—";
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
@@ -53,7 +57,7 @@ export default async function ApplicationDetailPage({
         </div>
         <dl className="mt-6 grid gap-4 sm:grid-cols-2">
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Applicant name
             </dt>
             <dd className="mt-0.5 text-gray-900">
@@ -61,23 +65,19 @@ export default async function ApplicationDetailPage({
             </dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Email
             </dt>
-            <dd className="mt-0.5 text-gray-900">
-              {readString(form.email)}
-            </dd>
+            <dd className="mt-0.5 text-gray-900">{readString(form.email)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Phone
             </dt>
-            <dd className="mt-0.5 text-gray-900">
-              {readString(form.phone)}
-            </dd>
+            <dd className="mt-0.5 text-gray-900">{readPhone(form.phone)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Event or initiative
             </dt>
             <dd className="mt-0.5 text-gray-900">
@@ -87,7 +87,7 @@ export default async function ApplicationDetailPage({
           {form.eventTitle != null && form.eventTitle !== "" && (
             <>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Event title
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -95,7 +95,7 @@ export default async function ApplicationDetailPage({
                 </dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Event date
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -107,7 +107,7 @@ export default async function ApplicationDetailPage({
           {form.initiativeTitle != null && form.initiativeTitle !== "" && (
             <>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Initiative title
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -115,7 +115,7 @@ export default async function ApplicationDetailPage({
                 </dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Initiative date
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -127,7 +127,7 @@ export default async function ApplicationDetailPage({
         </dl>
         {application.budgetFilePath && (
           <div className="mt-6">
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Budget file
             </dt>
             <a
@@ -145,13 +145,13 @@ export default async function ApplicationDetailPage({
           application.approvalConditions ??
           application.denialReason) && (
           <div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-4">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-800">
+            <h2 className="text-sm font-semibold tracking-wide text-gray-800 uppercase">
               Review outcome
             </h2>
             <dl className="mt-4 grid gap-4 sm:grid-cols-2">
               {application.reviewedAt && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Reviewed at
                   </dt>
                   <dd className="mt-0.5 text-gray-900">
@@ -161,17 +161,18 @@ export default async function ApplicationDetailPage({
               )}
               {application.reviewedBy && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Reviewed by
                   </dt>
                   <dd className="mt-0.5 text-gray-900">
-                    {application.reviewedBy.name} ({application.reviewedBy.email})
+                    {application.reviewedBy.name} (
+                    {application.reviewedBy.email})
                   </dd>
                 </div>
               )}
               {application.reviewerComments && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Acceptance comments
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">
@@ -181,7 +182,7 @@ export default async function ApplicationDetailPage({
               )}
               {application.approvalConditions && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Acceptance conditions
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">
@@ -191,7 +192,7 @@ export default async function ApplicationDetailPage({
               )}
               {application.denialReason && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Denial reason
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">

--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -6,6 +6,7 @@ import { createTRPCContext } from "~/server/api/trpc";
 import { headers } from "next/headers";
 import { ApplicationStatusBadge } from "~/components/seif/application-status-badge";
 import { formatTorontoDateTime } from "~/lib/date";
+import { formatStoredPhoneNumber } from "~/lib/phone";
 
 export const metadata = {
   title: "Application Details",
@@ -33,6 +34,7 @@ export default async function ApplicationDetailPage({
   const form = application.formData as Record<string, unknown>;
   const readString = (value: unknown) =>
     typeof value === "string" && value.length > 0 ? value : "—";
+  const readPhone = (value: unknown) => formatStoredPhoneNumber(value) ?? "—";
 
   return (
     <div className="mx-auto max-w-4xl py-8">
@@ -57,7 +59,7 @@ export default async function ApplicationDetailPage({
         </div>
         <dl className="mt-6 grid gap-4 sm:grid-cols-2">
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Applicant name
             </dt>
             <dd className="mt-0.5 text-gray-900">
@@ -65,23 +67,19 @@ export default async function ApplicationDetailPage({
             </dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Email
             </dt>
-            <dd className="mt-0.5 text-gray-900">
-              {readString(form.email)}
-            </dd>
+            <dd className="mt-0.5 text-gray-900">{readString(form.email)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Phone
             </dt>
-            <dd className="mt-0.5 text-gray-900">
-              {readString(form.phone)}
-            </dd>
+            <dd className="mt-0.5 text-gray-900">{readPhone(form.phone)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Event or initiative
             </dt>
             <dd className="mt-0.5 text-gray-900">
@@ -91,7 +89,7 @@ export default async function ApplicationDetailPage({
           {form.eventTitle != null && form.eventTitle !== "" && (
             <>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Event title
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -99,7 +97,7 @@ export default async function ApplicationDetailPage({
                 </dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Event date
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -111,7 +109,7 @@ export default async function ApplicationDetailPage({
           {form.initiativeTitle != null && form.initiativeTitle !== "" && (
             <>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Initiative title
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -119,7 +117,7 @@ export default async function ApplicationDetailPage({
                 </dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase text-gray-500">
+                <dt className="text-xs font-medium text-gray-500 uppercase">
                   Initiative date
                 </dt>
                 <dd className="mt-0.5 text-gray-900">
@@ -131,7 +129,7 @@ export default async function ApplicationDetailPage({
         </dl>
         {application.budgetFilePath && (
           <div className="mt-6">
-            <dt className="text-xs font-medium uppercase text-gray-500">
+            <dt className="text-xs font-medium text-gray-500 uppercase">
               Budget file
             </dt>
             <a
@@ -149,13 +147,13 @@ export default async function ApplicationDetailPage({
           application.approvalConditions ??
           application.denialReason) && (
           <div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-4">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-800">
+            <h2 className="text-sm font-semibold tracking-wide text-gray-800 uppercase">
               Review outcome
             </h2>
             <dl className="mt-4 grid gap-4 sm:grid-cols-2">
               {application.reviewedAt && (
                 <div>
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Reviewed at
                   </dt>
                   <dd className="mt-0.5 text-gray-900">
@@ -165,7 +163,7 @@ export default async function ApplicationDetailPage({
               )}
               {application.reviewerComments && (
                 <div className="sm:col-span-2">
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Comments
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">
@@ -175,7 +173,7 @@ export default async function ApplicationDetailPage({
               )}
               {application.approvalConditions && (
                 <div className="sm:col-span-2">
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Conditions
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">
@@ -185,7 +183,7 @@ export default async function ApplicationDetailPage({
               )}
               {application.denialReason && (
                 <div className="sm:col-span-2">
-                  <dt className="text-xs font-medium uppercase text-gray-500">
+                  <dt className="text-xs font-medium text-gray-500 uppercase">
                     Denial reason
                   </dt>
                   <dd className="mt-0.5 whitespace-pre-wrap text-gray-900">

--- a/src/components/seif/application-form.tsx
+++ b/src/components/seif/application-form.tsx
@@ -6,11 +6,7 @@ import type { RouterOutputs } from "~/trpc/react";
 import { authClient } from "~/server/better-auth/client";
 import { ChevronDown } from "lucide-react";
 import { BudgetFileUpload } from "~/components/ui/file-upload";
-import {
-  DEFAULT_PHONE_COUNTRY,
-  getFlagEmoji,
-  getPhoneInputState,
-} from "~/lib/phone";
+import { getFlagEmoji, getPhoneInputState } from "~/lib/phone";
 
 type Org = RouterOutputs["application"]["listOrganizations"][number];
 
@@ -337,10 +333,6 @@ function PhoneNumberField({
           aria-label="Phone Number"
         />
       </div>
-      <p className="mt-1 text-sm text-gray-500">
-        Country is detected from the number entered and defaults to{" "}
-        {DEFAULT_PHONE_COUNTRY === "CA" ? "Canada" : DEFAULT_PHONE_COUNTRY}.
-      </p>
     </div>
   );
 }

--- a/src/components/seif/application-form.tsx
+++ b/src/components/seif/application-form.tsx
@@ -326,6 +326,7 @@ function PhoneNumberField({
   const inputRef = useRef<HTMLInputElement>(null);
   const nextSelectionRef = useRef<number | null>(null);
   const { detectedCountry, callingCode, isValid } = getPhoneInputState(value);
+  const showCodeInBadge = !value.trimStart().startsWith("+");
 
   useEffect(() => {
     const input = inputRef.current;
@@ -378,7 +379,7 @@ function PhoneNumberField({
           <span aria-hidden className="text-lg leading-none">
             {getFlagEmoji(detectedCountry)}
           </span>
-          <span className="font-medium">{callingCode}</span>
+          {showCodeInBadge && <span className="font-medium">{callingCode}</span>}
         </div>
         <input
           ref={inputRef}
@@ -484,7 +485,7 @@ export function ApplicationForm() {
       setSubmitError("Please enter a valid amount requested.");
       return;
     }
-    if (typeof formData.phone !== "string" || formData.phone.length === 0) {
+    if (!getPhoneInputState(formData.phone).isValid) {
       setSubmitError("Please enter a valid phone number.");
       return;
     }

--- a/src/components/seif/application-form.tsx
+++ b/src/components/seif/application-form.tsx
@@ -6,6 +6,11 @@ import type { RouterOutputs } from "~/trpc/react";
 import { authClient } from "~/server/better-auth/client";
 import { ChevronDown } from "lucide-react";
 import { BudgetFileUpload } from "~/components/ui/file-upload";
+import {
+  DEFAULT_PHONE_COUNTRY,
+  getFlagEmoji,
+  getPhoneInputState,
+} from "~/lib/phone";
 
 type Org = RouterOutputs["application"]["listOrganizations"][number];
 
@@ -16,7 +21,10 @@ function loadDraft(): { formData: FormData; budgetPath: string } | null {
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as { formData: FormData; budgetPath?: string };
+    const parsed = JSON.parse(raw) as {
+      formData: FormData;
+      budgetPath?: string;
+    };
     return {
       formData: parsed.formData ?? {},
       budgetPath: parsed.budgetPath ?? "",
@@ -29,10 +37,7 @@ function loadDraft(): { formData: FormData; budgetPath: string } | null {
 function saveDraft(formData: FormData, budgetPath: string) {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(
-      DRAFT_KEY,
-      JSON.stringify({ formData, budgetPath })
-    );
+    localStorage.setItem(DRAFT_KEY, JSON.stringify({ formData, budgetPath }));
   } catch {
     // ignore
   }
@@ -68,15 +73,42 @@ const PREAMBLE = `NEW! Effective 1/15/2025, the yearly limit for SEIF has double
 Requests for financial support may cover, but are not limited to, promotion, technical assistance, event supplies, and transportation. SEIF is not granted for operational costs, salaries, or alcohol costs. Priority goes to applications that will have the greatest impact on the undergraduate population at the University of Guelph. In fairness to all organizations, no group will be awarded more than $1,000 in any fiscal year (May-April). In order to qualify for future funding, recipients of SEIF funds must complete the SEIF Funding Report within two weeks of the event or initiative. Thank you for reading! If you have any questions regarding the completion of this form, please consult our website or reach out via email at csaclubs@uoguelph.ca.`;
 
 const TERMS_STATEMENTS: { key: string; text: string }[] = [
-  { key: "termsRead", text: "I have read the relevant policy, rules and guidelines regarding the SEIF process (available on the CSA website)." },
-  { key: "termsTemplate", text: "I understand that by not following the directions laid out or submitting a budget without using the provided template that my application will not be considered." },
-  { key: "termsReturn", text: "I understand that I must return any funds that are unused, and must return all funds if the event is cancelled." },
-  { key: "termsReport", text: "I understand that in order to qualify for future funding, recipients of SEIF funding must submit the report to the CSA within two weeks of the event or initiative (or within two weeks of receiving notification of funding for previous events/initiatives)." },
-  { key: "termsOnlyForm", text: "I acknowledge that only information provided in this form will be considered for SEIF assessment unless indicated otherwise." },
-  { key: "termsNoReconsideration", text: "I understand that reconsideration on the ground of providing more information after the application has been assessed will not be entertained." },
-  { key: "termsOrgIneligible", text: "I understand that failure to follow the guidelines set in the SEIF process or by submitting false information my organization will not be eligible to apply for SEIF in the future." },
-  { key: "termsApplicantIneligible", text: "I understand that failure to follow the guidelines set in the SEIF process or by submitting false information I (the individual applying) will not be eligible to apply for SEIF in the future for this organization or any other organization in the future." },
-  { key: "termsCertify", text: "I acknowledge that by signing this form, it certifies that all information provided in this form is true and I understand the terms and conditions of the SEIF Process." },
+  {
+    key: "termsRead",
+    text: "I have read the relevant policy, rules and guidelines regarding the SEIF process (available on the CSA website).",
+  },
+  {
+    key: "termsTemplate",
+    text: "I understand that by not following the directions laid out or submitting a budget without using the provided template that my application will not be considered.",
+  },
+  {
+    key: "termsReturn",
+    text: "I understand that I must return any funds that are unused, and must return all funds if the event is cancelled.",
+  },
+  {
+    key: "termsReport",
+    text: "I understand that in order to qualify for future funding, recipients of SEIF funding must submit the report to the CSA within two weeks of the event or initiative (or within two weeks of receiving notification of funding for previous events/initiatives).",
+  },
+  {
+    key: "termsOnlyForm",
+    text: "I acknowledge that only information provided in this form will be considered for SEIF assessment unless indicated otherwise.",
+  },
+  {
+    key: "termsNoReconsideration",
+    text: "I understand that reconsideration on the ground of providing more information after the application has been assessed will not be entertained.",
+  },
+  {
+    key: "termsOrgIneligible",
+    text: "I understand that failure to follow the guidelines set in the SEIF process or by submitting false information my organization will not be eligible to apply for SEIF in the future.",
+  },
+  {
+    key: "termsApplicantIneligible",
+    text: "I understand that failure to follow the guidelines set in the SEIF process or by submitting false information I (the individual applying) will not be eligible to apply for SEIF in the future for this organization or any other organization in the future.",
+  },
+  {
+    key: "termsCertify",
+    text: "I acknowledge that by signing this form, it certifies that all information provided in this form is true and I understand the terms and conditions of the SEIF Process.",
+  },
 ];
 
 function Label({
@@ -116,7 +148,7 @@ function SearchableOrganizationSelect({
   const selectedOrg = organizations.find((o) => o.id === value);
   const filtered = query.trim()
     ? organizations.filter((o) =>
-        o.name.toLowerCase().includes(query.toLowerCase())
+        o.name.toLowerCase().includes(query.toLowerCase()),
       )
     : organizations;
 
@@ -135,7 +167,10 @@ function SearchableOrganizationSelect({
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
         setOpen(false);
       }
     }
@@ -179,18 +214,27 @@ function SearchableOrganizationSelect({
 
   return (
     <div ref={containerRef} className="relative">
-      <input type="hidden" name="organizationId" value={value} required={required} />
+      <input
+        type="hidden"
+        name="organizationId"
+        value={value}
+        required={required}
+      />
       <div
         role="combobox"
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls="org-listbox"
-        aria-activedescendant={filtered[highlightIndex] ? `org-option-${filtered[highlightIndex].id}` : undefined}
-        className="flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-gray-900 shadow-sm focus-within:border-indigo-500 focus-within:outline-none focus-within:ring-1 focus-within:ring-indigo-500"
+        aria-activedescendant={
+          filtered[highlightIndex]
+            ? `org-option-${filtered[highlightIndex].id}`
+            : undefined
+        }
+        className="flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-gray-900 shadow-sm focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500 focus-within:outline-none"
       >
         <input
           type="text"
-          value={open ? query : selectedOrg?.name ?? ""}
+          value={open ? query : (selectedOrg?.name ?? "")}
           onChange={(e) => {
             setQuery(e.target.value);
             setOpen(true);
@@ -218,7 +262,9 @@ function SearchableOrganizationSelect({
           className="shrink-0 text-gray-400 hover:text-gray-600"
           aria-label={open ? "Close list" : "Open list"}
         >
-          <ChevronDown className={`h-4 w-4 transition ${open ? "rotate-180" : ""}`} />
+          <ChevronDown
+            className={`h-4 w-4 transition ${open ? "rotate-180" : ""}`}
+          />
         </button>
       </div>
       {open && (
@@ -229,7 +275,9 @@ function SearchableOrganizationSelect({
           className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
         >
           {filtered.length === 0 ? (
-            <li className="px-3 py-2 text-sm text-gray-500">No organizations match</li>
+            <li className="px-3 py-2 text-sm text-gray-500">
+              No organizations match
+            </li>
           ) : (
             filtered.map((org, i) => (
               <li
@@ -255,6 +303,48 @@ function SearchableOrganizationSelect({
   );
 }
 
+function PhoneNumberField({
+  value,
+  onChange,
+  required,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+}) {
+  const { formatted, detectedCountry, callingCode } = getPhoneInputState(value);
+
+  return (
+    <div>
+      <div className="flex overflow-hidden rounded-md border border-gray-300 bg-white shadow-sm focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500">
+        <div className="flex shrink-0 items-center gap-2 border-r border-gray-300 bg-gray-50 px-3 text-sm text-gray-700">
+          <span aria-hidden className="text-lg leading-none">
+            {getFlagEmoji(detectedCountry)}
+          </span>
+          <span className="font-medium">{callingCode}</span>
+        </div>
+        <input
+          type="tel"
+          inputMode="tel"
+          autoComplete="tel"
+          className="min-w-0 flex-1 border-0 px-3 py-2 text-gray-900 outline-none placeholder:text-gray-500 focus:ring-0"
+          value={formatted}
+          onChange={(e) =>
+            onChange(getPhoneInputState(e.target.value).formatted)
+          }
+          placeholder="(519) 555-1234"
+          required={required}
+          aria-label="Phone Number"
+        />
+      </div>
+      <p className="mt-1 text-sm text-gray-500">
+        Country is detected from the number entered and defaults to{" "}
+        {DEFAULT_PHONE_COUNTRY === "CA" ? "Canada" : DEFAULT_PHONE_COUNTRY}.
+      </p>
+    </div>
+  );
+}
+
 export function ApplicationForm() {
   const { data: session } = authClient.useSession();
   const [formData, setFormData] = useState<FormData>({});
@@ -271,7 +361,13 @@ export function ApplicationForm() {
     if (draftRestored) return;
     const draft = loadDraft();
     if (draft && (Object.keys(draft.formData).length > 0 || draft.budgetPath)) {
-      setFormData(draft.formData);
+      const draftPhone = draft.formData.phone;
+      setFormData({
+        ...draft.formData,
+        ...(typeof draftPhone === "string"
+          ? { phone: getPhoneInputState(draftPhone).formatted }
+          : {}),
+      });
       setBudgetPath(draft.budgetPath);
     }
     setDraftRestored(true);
@@ -314,7 +410,9 @@ export function ApplicationForm() {
         provider: "microsoft",
         callbackURL: "/apply",
       });
-      setSubmitError("Please sign in to submit. Your responses have been saved and will be restored when you return.");
+      setSubmitError(
+        "Please sign in to submit. Your responses have been saved and will be restored when you return.",
+      );
       return;
     }
 
@@ -349,7 +447,9 @@ export function ApplicationForm() {
           Organization Representation
         </h2>
         <div className="mt-4">
-          <Label required>Organization for which you are making this submission</Label>
+          <Label required>
+            Organization for which you are making this submission
+          </Label>
           <SearchableOrganizationSelect
             organizations={organizations}
             value={(formData.organizationId as string) ?? ""}
@@ -368,7 +468,7 @@ export function ApplicationForm() {
       {/* Preamble */}
       <section className="rounded-lg border border-gray-200 bg-amber-50/50 p-6">
         <h2 className="text-lg font-semibold text-gray-900">Preamble</h2>
-        <p className="mt-2 whitespace-pre-line text-sm text-gray-700">
+        <p className="mt-2 text-sm whitespace-pre-line text-gray-700">
           {PREAMBLE}
         </p>
       </section>
@@ -383,7 +483,7 @@ export function ApplicationForm() {
             <Label required>Full Name</Label>
             <input
               type="text"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               value={(formData.fullName as string) ?? ""}
               onChange={(e) => update("fullName", e.target.value)}
               required
@@ -393,7 +493,7 @@ export function ApplicationForm() {
             <Label required>UofG Email Address</Label>
             <input
               type="email"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               value={(formData.email as string) ?? ""}
               onChange={(e) => update("email", e.target.value)}
               required
@@ -401,11 +501,9 @@ export function ApplicationForm() {
           </div>
           <div>
             <Label required>Phone Number</Label>
-            <input
-              type="tel"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            <PhoneNumberField
               value={(formData.phone as string) ?? ""}
-              onChange={(e) => update("phone", e.target.value)}
+              onChange={(value) => update("phone", value)}
               required
             />
           </div>
@@ -418,11 +516,14 @@ export function ApplicationForm() {
           Organization Information
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          A CSA Club is accredited through the CSA and holds a CSA Club bank account. Non-CSA clubs receive funding via cheque.
+          A CSA Club is accredited through the CSA and holds a CSA Club bank
+          account. Non-CSA clubs receive funding via cheque.
         </p>
         <div className="mt-4 space-y-4">
           <div>
-            <Label required>Is your organization accredited through the CSA?</Label>
+            <Label required>
+              Is your organization accredited through the CSA?
+            </Label>
             <div className="flex gap-6 pt-1">
               {["Yes", "No"].map((opt) => (
                 <label key={opt} className="flex items-center gap-2">
@@ -460,10 +561,12 @@ export function ApplicationForm() {
         </div>
         {showExternalBanking && (
           <div className="mt-4">
-            <Label required>Name to be written on the cheque (registered bank account name)</Label>
+            <Label required>
+              Name to be written on the cheque (registered bank account name)
+            </Label>
             <input
               type="text"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               value={(formData.chequeName as string) ?? ""}
               onChange={(e) => update("chequeName", e.target.value)}
               required
@@ -473,7 +576,9 @@ export function ApplicationForm() {
         )}
         {showNonCsaOrg && (
           <div className="mt-4">
-            <Label required>What Primary Student Organization is your club accredited under?</Label>
+            <Label required>
+              What Primary Student Organization is your club accredited under?
+            </Label>
             <div className="mt-2 space-y-2">
               {PRIMARY_ORGS.map((org) => (
                 <label key={org} className="flex items-center gap-2">
@@ -498,107 +603,135 @@ export function ApplicationForm() {
           Other Sources of Funding
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          If your event/initiative results in a surplus, you will be required to return the awarded funds to the CSA. Requests may not be approved if your budget indicates a surplus.
+          If your event/initiative results in a surplus, you will be required to
+          return the awarded funds to the CSA. Requests may not be approved if
+          your budget indicates a surplus.
         </p>
         <div className="mt-4 space-y-4">
           <div>
             <Label required>Funding received to date</Label>
             <div className="mt-2 space-y-3">
-              {["None", "Student Life Enhancement Fund (SLEF)", "Other PDR Requests", "Other"].map(
-                (opt) => {
-                  const received = (formData.fundingReceived as string[]) ?? [];
-                  const checked = received.includes(opt);
-                  const amounts = (formData.fundingReceivedAmounts as Record<string, string>) ?? {};
-                  return (
-                    <div key={opt} className="flex flex-wrap items-center justify-between gap-2">
-                      <label className="flex items-center gap-2">
+              {[
+                "None",
+                "Student Life Enhancement Fund (SLEF)",
+                "Other PDR Requests",
+                "Other",
+              ].map((opt) => {
+                const received = (formData.fundingReceived as string[]) ?? [];
+                const checked = received.includes(opt);
+                const amounts =
+                  (formData.fundingReceivedAmounts as Record<string, string>) ??
+                  {};
+                return (
+                  <div
+                    key={opt}
+                    className="flex flex-wrap items-center justify-between gap-2"
+                  >
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => {
+                          const next = e.target.checked
+                            ? [...received, opt]
+                            : received.filter((x) => x !== opt);
+                          update("fundingReceived", next);
+                          if (!e.target.checked) {
+                            const nextAmounts = { ...amounts };
+                            delete nextAmounts[opt];
+                            update("fundingReceivedAmounts", nextAmounts);
+                          }
+                        }}
+                      />
+                      <span>{opt}</span>
+                    </label>
+                    {checked && opt !== "None" && (
+                      <div className="flex items-center gap-2">
+                        <span className="text-right text-sm text-gray-600">
+                          Amount received ($)
+                        </span>
                         <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={(e) => {
-                            const next = e.target.checked
-                              ? [...received, opt]
-                              : received.filter((x) => x !== opt);
-                            update("fundingReceived", next);
-                            if (!e.target.checked) {
-                              const nextAmounts = { ...amounts };
-                              delete nextAmounts[opt];
-                              update("fundingReceivedAmounts", nextAmounts);
-                            }
-                          }}
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          placeholder="0"
+                          className="w-28 rounded-md border border-gray-300 px-2 py-1.5 text-right text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                          value={amounts[opt] ?? ""}
+                          onChange={(e) =>
+                            update("fundingReceivedAmounts", {
+                              ...amounts,
+                              [opt]: e.target.value,
+                            })
+                          }
                         />
-                        <span>{opt}</span>
-                      </label>
-                      {checked && opt !== "None" && (
-                        <div className="flex items-center gap-2">
-                          <span className="text-right text-sm text-gray-600">Amount received ($)</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            placeholder="0"
-                            className="w-28 rounded-md border border-gray-300 px-2 py-1.5 text-right text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                            value={amounts[opt] ?? ""}
-                            onChange={(e) =>
-                              update("fundingReceivedAmounts", { ...amounts, [opt]: e.target.value })
-                            }
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                }
-              )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
           <div>
             <Label required>Funding you expect to receive</Label>
             <div className="mt-2 space-y-3">
-              {["None", "Student Life Enhancement Fund (SLEF)", "Other PDR Requests", "Other"].map(
-                (opt) => {
-                  const expected = (formData.fundingExpected as string[]) ?? [];
-                  const checked = expected.includes(opt);
-                  const amounts = (formData.fundingExpectedAmounts as Record<string, string>) ?? {};
-                  return (
-                    <div key={opt} className="flex flex-wrap items-center justify-between gap-2">
-                      <label className="flex items-center gap-2">
+              {[
+                "None",
+                "Student Life Enhancement Fund (SLEF)",
+                "Other PDR Requests",
+                "Other",
+              ].map((opt) => {
+                const expected = (formData.fundingExpected as string[]) ?? [];
+                const checked = expected.includes(opt);
+                const amounts =
+                  (formData.fundingExpectedAmounts as Record<string, string>) ??
+                  {};
+                return (
+                  <div
+                    key={opt}
+                    className="flex flex-wrap items-center justify-between gap-2"
+                  >
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => {
+                          const next = e.target.checked
+                            ? [...expected, opt]
+                            : expected.filter((x) => x !== opt);
+                          update("fundingExpected", next);
+                          if (!e.target.checked) {
+                            const nextAmounts = { ...amounts };
+                            delete nextAmounts[opt];
+                            update("fundingExpectedAmounts", nextAmounts);
+                          }
+                        }}
+                      />
+                      <span>{opt}</span>
+                    </label>
+                    {checked && opt !== "None" && (
+                      <div className="flex items-center gap-2">
+                        <span className="text-right text-sm text-gray-600">
+                          Amount expected ($)
+                        </span>
                         <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={(e) => {
-                            const next = e.target.checked
-                              ? [...expected, opt]
-                              : expected.filter((x) => x !== opt);
-                            update("fundingExpected", next);
-                            if (!e.target.checked) {
-                              const nextAmounts = { ...amounts };
-                              delete nextAmounts[opt];
-                              update("fundingExpectedAmounts", nextAmounts);
-                            }
-                          }}
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          placeholder="0"
+                          className="w-28 rounded-md border border-gray-300 px-2 py-1.5 text-right text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                          value={amounts[opt] ?? ""}
+                          onChange={(e) =>
+                            update("fundingExpectedAmounts", {
+                              ...amounts,
+                              [opt]: e.target.value,
+                            })
+                          }
                         />
-                        <span>{opt}</span>
-                      </label>
-                      {checked && opt !== "None" && (
-                        <div className="flex items-center gap-2">
-                          <span className="text-right text-sm text-gray-600">Amount expected ($)</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            placeholder="0"
-                            className="w-28 rounded-md border border-gray-300 px-2 py-1.5 text-right text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                            value={amounts[opt] ?? ""}
-                            onChange={(e) =>
-                              update("fundingExpectedAmounts", { ...amounts, [opt]: e.target.value })
-                            }
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                }
-              )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>
@@ -610,10 +743,14 @@ export function ApplicationForm() {
           Event/Initiative Details
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          An event is a planned occasion (e.g. CSA Sexy Bingo). An initiative has clear objectives and timelines over a longer period (e.g. Menstrual Hygiene Initiative).
+          An event is a planned occasion (e.g. CSA Sexy Bingo). An initiative
+          has clear objectives and timelines over a longer period (e.g.
+          Menstrual Hygiene Initiative).
         </p>
         <div className="mt-4">
-          <Label required>Are you applying for an event or an initiative?</Label>
+          <Label required>
+            Are you applying for an event or an initiative?
+          </Label>
           <div className="flex gap-6 pt-1">
             {["Event", "Initiative"].map((opt) => (
               <label key={opt} className="flex items-center gap-2">
@@ -640,7 +777,7 @@ export function ApplicationForm() {
               <Label required>Event Title</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.eventTitle as string) ?? ""}
                 onChange={(e) => update("eventTitle", e.target.value)}
                 required
@@ -650,7 +787,7 @@ export function ApplicationForm() {
               <Label required>Event Location</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.eventLocation as string) ?? ""}
                 onChange={(e) => update("eventLocation", e.target.value)}
                 required
@@ -660,14 +797,17 @@ export function ApplicationForm() {
               <Label required>Event Date</Label>
               <input
                 type="date"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.eventDate as string) ?? ""}
                 onChange={(e) => update("eventDate", e.target.value)}
                 required
               />
             </div>
             <div>
-              <Label required>Has this event been submitted to the Student Events & Risk Management process (GryphLife)?</Label>
+              <Label required>
+                Has this event been submitted to the Student Events & Risk
+                Management process (GryphLife)?
+              </Label>
               <p className="mb-1 text-sm text-gray-600">
                 The event does not need to be approved yet, just submitted.
               </p>
@@ -687,33 +827,43 @@ export function ApplicationForm() {
               </div>
               {formData.eventGryphLife === "No" && (
                 <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-800">
-                  All events submitted to SEIF must be submitted on GryphLife for Student Events &amp; Risk Management (SE&amp;RM) review. Please submit your event on GryphLife before continuing your SEIF application.
+                  All events submitted to SEIF must be submitted on GryphLife
+                  for Student Events &amp; Risk Management (SE&amp;RM) review.
+                  Please submit your event on GryphLife before continuing your
+                  SEIF application.
                 </div>
               )}
             </div>
             <div>
               <Label required>Event type that best describes your event</Label>
               <div className="mt-2 flex flex-wrap gap-4">
-                {["Networking", "Community-Building", "Competition", "Conference", "Demonstration", "Show, or Performance", "Fundraising for a charitable organization", "Other"].map(
-                  (opt) => (
-                    <label key={opt} className="flex items-center gap-2">
-                      <input
-                        type="radio"
-                        name="eventType"
-                        value={opt}
-                        checked={(formData.eventType as string) === opt}
-                        onChange={() => update("eventType", opt)}
-                      />
-                      <span>{opt}</span>
-                    </label>
-                  )
-                )}
+                {[
+                  "Networking",
+                  "Community-Building",
+                  "Competition",
+                  "Conference",
+                  "Demonstration",
+                  "Show, or Performance",
+                  "Fundraising for a charitable organization",
+                  "Other",
+                ].map((opt) => (
+                  <label key={opt} className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="eventType"
+                      value={opt}
+                      checked={(formData.eventType as string) === opt}
+                      onChange={() => update("eventType", opt)}
+                    />
+                    <span>{opt}</span>
+                  </label>
+                ))}
               </div>
             </div>
             <div>
               <Label required>Description of the event</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={4}
                 value={(formData.eventDescription as string) ?? ""}
                 onChange={(e) => update("eventDescription", e.target.value)}
@@ -723,7 +873,7 @@ export function ApplicationForm() {
             <div>
               <Label>Co-sponsors (if any)</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={2}
                 value={(formData.eventCosponsors as string) ?? ""}
                 onChange={(e) => update("eventCosponsors", e.target.value)}
@@ -733,7 +883,7 @@ export function ApplicationForm() {
               <Label required>Expected number of participants</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.eventParticipants as string) ?? ""}
                 onChange={(e) => update("eventParticipants", e.target.value)}
                 required
@@ -743,9 +893,11 @@ export function ApplicationForm() {
               <Label required>Breakdown: students vs community members</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.eventParticipantsBreakdown as string) ?? ""}
-                onChange={(e) => update("eventParticipantsBreakdown", e.target.value)}
+                onChange={(e) =>
+                  update("eventParticipantsBreakdown", e.target.value)
+                }
                 placeholder="e.g. 50 students, 10 community"
                 required
               />
@@ -753,7 +905,7 @@ export function ApplicationForm() {
             <div>
               <Label required>How will you advertise?</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={3}
                 value={(formData.eventAdvertising as string) ?? ""}
                 onChange={(e) => update("eventAdvertising", e.target.value)}
@@ -778,9 +930,11 @@ export function ApplicationForm() {
               </div>
               {formData.eventFee === "Yes" && (
                 <div className="mt-3">
-                  <Label required>How much is the fee, and what does it cover?</Label>
+                  <Label required>
+                    How much is the fee, and what does it cover?
+                  </Label>
                   <textarea
-                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                     rows={2}
                     value={(formData.eventFeeDetails as string) ?? ""}
                     onChange={(e) => update("eventFeeDetails", e.target.value)}
@@ -791,7 +945,11 @@ export function ApplicationForm() {
               )}
             </div>
             <div>
-              <Label required>The event date/time does not conflict with any religious or otherwise culturally important date(s) (see Religious Holidays Calendar).</Label>
+              <Label required>
+                The event date/time does not conflict with any religious or
+                otherwise culturally important date(s) (see Religious Holidays
+                Calendar).
+              </Label>
               <div className="flex gap-6 pt-1">
                 {["Yes", "No"].map((opt) => (
                   <label key={opt} className="flex items-center gap-2">
@@ -810,17 +968,21 @@ export function ApplicationForm() {
                 <div className="mt-3">
                   <Label required>If no, please explain.</Label>
                   <textarea
-                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                     rows={2}
                     value={(formData.eventNoConflictExplain as string) ?? ""}
-                    onChange={(e) => update("eventNoConflictExplain", e.target.value)}
+                    onChange={(e) =>
+                      update("eventNoConflictExplain", e.target.value)
+                    }
                     required
                   />
                 </div>
               )}
             </div>
             <div>
-              <Label required>Can anyone (including community members) attend?</Label>
+              <Label required>
+                Can anyone (including community members) attend?
+              </Label>
               <div className="flex gap-6 pt-1">
                 {["Yes", "No"].map((opt) => (
                   <label key={opt} className="flex items-center gap-2">
@@ -840,9 +1002,11 @@ export function ApplicationForm() {
                   <Label required>Specify who cannot attend your event.</Label>
                   <input
                     type="text"
-                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                     value={(formData.eventOpenToAllSpecify as string) ?? ""}
-                    onChange={(e) => update("eventOpenToAllSpecify", e.target.value)}
+                    onChange={(e) =>
+                      update("eventOpenToAllSpecify", e.target.value)
+                    }
                     required
                   />
                 </div>
@@ -851,7 +1015,7 @@ export function ApplicationForm() {
             <div>
               <Label required>How will you make the event accessible?</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={3}
                 value={(formData.eventAccessible as string) ?? ""}
                 onChange={(e) => update("eventAccessible", e.target.value)}
@@ -865,13 +1029,15 @@ export function ApplicationForm() {
       {/* Initiative Details (conditional) */}
       {isInitiative && (
         <section className="rounded-lg border border-gray-200 bg-emerald-50/30 p-6">
-          <h2 className="text-lg font-semibold text-gray-900">Initiative Details</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Initiative Details
+          </h2>
           <div className="mt-4 space-y-4">
             <div>
               <Label required>Initiative Title</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.initiativeTitle as string) ?? ""}
                 onChange={(e) => update("initiativeTitle", e.target.value)}
                 required
@@ -881,7 +1047,7 @@ export function ApplicationForm() {
               <Label required>Initiative Location</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.initiativeLocation as string) ?? ""}
                 onChange={(e) => update("initiativeLocation", e.target.value)}
                 required
@@ -891,29 +1057,32 @@ export function ApplicationForm() {
               <Label required>Initiative Date (or date range)</Label>
               <input
                 type="date"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.initiativeDate as string) ?? ""}
                 onChange={(e) => update("initiativeDate", e.target.value)}
                 required
               />
               <p className="mt-1 text-xs text-gray-500">
-                For a date range, use the start date. You can describe the full range in the description below.
+                For a date range, use the start date. You can describe the full
+                range in the description below.
               </p>
             </div>
             <div>
               <Label required>Description of the initiative</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={4}
                 value={(formData.initiativeDescription as string) ?? ""}
-                onChange={(e) => update("initiativeDescription", e.target.value)}
+                onChange={(e) =>
+                  update("initiativeDescription", e.target.value)
+                }
                 required
               />
             </div>
             <div>
               <Label required>Co-sponsors (if any)</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={2}
                 value={(formData.initiativeCosponsors as string) ?? ""}
                 onChange={(e) => update("initiativeCosponsors", e.target.value)}
@@ -923,7 +1092,7 @@ export function ApplicationForm() {
               <Label required>How many individuals will be impacted?</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.initiativeImpact as string) ?? ""}
                 onChange={(e) => update("initiativeImpact", e.target.value)}
                 required
@@ -933,7 +1102,7 @@ export function ApplicationForm() {
               <Label required>Breakdown: students vs community members</Label>
               <input
                 type="text"
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 value={(formData.initiativeBreakdown as string) ?? ""}
                 onChange={(e) => update("initiativeBreakdown", e.target.value)}
                 required
@@ -942,15 +1111,19 @@ export function ApplicationForm() {
             <div>
               <Label required>How will you advertise?</Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={3}
                 value={(formData.initiativeAdvertising as string) ?? ""}
-                onChange={(e) => update("initiativeAdvertising", e.target.value)}
+                onChange={(e) =>
+                  update("initiativeAdvertising", e.target.value)
+                }
                 required
               />
             </div>
             <div>
-              <Label required>Is there a fee associated with being part of the initiative?</Label>
+              <Label required>
+                Is there a fee associated with being part of the initiative?
+              </Label>
               <div className="flex gap-6 pt-1">
                 {["Yes", "No"].map((opt) => (
                   <label key={opt} className="flex items-center gap-2">
@@ -967,12 +1140,16 @@ export function ApplicationForm() {
               </div>
               {formData.initiativeFee === "Yes" && (
                 <div className="mt-3">
-                  <Label required>If yes, how much is the fee, and what does it cover?</Label>
+                  <Label required>
+                    If yes, how much is the fee, and what does it cover?
+                  </Label>
                   <textarea
-                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                     rows={2}
                     value={(formData.initiativeFeeDetails as string) ?? ""}
-                    onChange={(e) => update("initiativeFeeDetails", e.target.value)}
+                    onChange={(e) =>
+                      update("initiativeFeeDetails", e.target.value)
+                    }
                     placeholder="e.g. $10 — covers materials"
                     required
                   />
@@ -980,9 +1157,11 @@ export function ApplicationForm() {
               )}
             </div>
             <div>
-              <Label required>How will you make the initiative accessible?</Label>
+              <Label required>
+                How will you make the initiative accessible?
+              </Label>
               <textarea
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                 rows={3}
                 value={(formData.initiativeAccessible as string) ?? ""}
                 onChange={(e) => update("initiativeAccessible", e.target.value)}
@@ -995,10 +1174,15 @@ export function ApplicationForm() {
 
       {/* Previous Funding */}
       <section className="rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900">Previous Funding</h2>
+        <h2 className="text-lg font-semibold text-gray-900">
+          Previous Funding
+        </h2>
         <div className="mt-4 space-y-4">
           <div>
-            <Label required>Has your organization received SEIF funding this year for another event or initiative?</Label>
+            <Label required>
+              Has your organization received SEIF funding this year for another
+              event or initiative?
+            </Label>
             <div className="flex gap-6 pt-1">
               {["Yes", "I'm not sure", "No"].map((opt) => (
                 <label key={opt} className="flex items-center gap-2">
@@ -1018,7 +1202,7 @@ export function ApplicationForm() {
                 <Label required>If yes, how much?</Label>
                 <input
                   type="text"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
                   value={(formData.seifThisYearAmount as string) ?? ""}
                   onChange={(e) => update("seifThisYearAmount", e.target.value)}
                   placeholder="e.g. $250"
@@ -1028,7 +1212,10 @@ export function ApplicationForm() {
             )}
           </div>
           <div>
-            <Label required>Has your organization received SEIF funding for the same event/initiative in the past?</Label>
+            <Label required>
+              Has your organization received SEIF funding for the same
+              event/initiative in the past?
+            </Label>
             <div className="flex gap-6 pt-1">
               {["Yes", "I'm not sure", "No"].map((opt) => (
                 <label key={opt} className="flex items-center gap-2">
@@ -1049,9 +1236,12 @@ export function ApplicationForm() {
 
       {/* Financial Information */}
       <section className="rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900">Financial Information</h2>
+        <h2 className="text-lg font-semibold text-gray-900">
+          Financial Information
+        </h2>
         <p className="mt-1 text-sm text-gray-600">
-          Please use the budget template below. Budgets not submitted using the template will not be accepted.
+          Please use the budget template below. Budgets not submitted using the
+          template will not be accepted.
         </p>
         <div className="mt-4 space-y-4">
           <div>
@@ -1080,16 +1270,19 @@ export function ApplicationForm() {
               type="number"
               min="0"
               step="0.01"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               value={(formData.amountRequested as string) ?? ""}
               onChange={(e) => update("amountRequested", e.target.value)}
               required
             />
           </div>
           <div>
-            <Label required>If you do not receive full funding, how will this impact the event? What portion of your budget is CSA funding?</Label>
+            <Label required>
+              If you do not receive full funding, how will this impact the
+              event? What portion of your budget is CSA funding?
+            </Label>
             <textarea
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               rows={4}
               value={(formData.impactPartialFunding as string) ?? ""}
               onChange={(e) => update("impactPartialFunding", e.target.value)}
@@ -1099,7 +1292,7 @@ export function ApplicationForm() {
           <div>
             <Label>Anything else the SEIF Committee should know?</Label>
             <textarea
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               rows={3}
               value={(formData.additionalInfo as string) ?? ""}
               onChange={(e) => update("additionalInfo", e.target.value)}
@@ -1110,13 +1303,19 @@ export function ApplicationForm() {
 
       {/* Terms & Conditions */}
       <section className="rounded-lg border border-gray-200 bg-gray-50 p-6">
-        <h2 className="text-lg font-semibold text-gray-900">Terms & Conditions</h2>
+        <h2 className="text-lg font-semibold text-gray-900">
+          Terms & Conditions
+        </h2>
         <p className="mt-2 text-sm text-gray-600">
-          Please check each box next to the statement and enter your name as a digital signature.
+          Please check each box next to the statement and enter your name as a
+          digital signature.
         </p>
         <div className="mt-4 space-y-3">
           {TERMS_STATEMENTS.map(({ key, text }) => (
-            <label key={key} className="flex items-start gap-3 text-sm text-gray-700">
+            <label
+              key={key}
+              className="flex items-start gap-3 text-sm text-gray-700"
+            >
               <input
                 type="checkbox"
                 className="mt-0.5 shrink-0"
@@ -1131,7 +1330,7 @@ export function ApplicationForm() {
             <Label required>Digital signature (your full name)</Label>
             <input
               type="text"
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
               value={(formData.signature as string) ?? ""}
               onChange={(e) => update("signature", e.target.value)}
               placeholder="Type your full name"
@@ -1149,7 +1348,8 @@ export function ApplicationForm() {
 
       {!session?.user && (
         <p className="text-sm text-amber-700">
-          You must sign in to submit. Your responses are saved automatically and will be here when you return.
+          You must sign in to submit. Your responses are saved automatically and
+          will be here when you return.
         </p>
       )}
       <div className="flex justify-end gap-4">
@@ -1158,7 +1358,11 @@ export function ApplicationForm() {
           disabled={create.isPending}
           className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50"
         >
-          {create.isPending ? "Submitting…" : session?.user ? "Submit Application" : "Sign in to submit"}
+          {create.isPending
+            ? "Submitting…"
+            : session?.user
+              ? "Submit Application"
+              : "Sign in to submit"}
         </button>
       </div>
     </form>

--- a/src/components/seif/application-form.tsx
+++ b/src/components/seif/application-form.tsx
@@ -357,14 +357,14 @@ function PhoneNumberField({
     for (const [index, char] of [...nextState.formatted].entries()) {
       if (/\d/.test(char)) {
         digitsSeen += 1;
-      }
-      if (digitsSeen >= digitIndex) {
-        nextSelection = index + 1;
-        break;
+        if (digitsSeen >= digitIndex) {
+          nextSelection = index + 1;
+          break;
+        }
       }
     }
 
-    nextSelectionRef.current = nextSelection;
+    nextSelectionRef.current = digitIndex === 0 ? 0 : nextSelection;
     onChange({
       displayValue: nextState.formatted,
       storedValue: nextState.e164 ?? "",

--- a/src/components/seif/application-form.tsx
+++ b/src/components/seif/application-form.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import { api } from "~/trpc/react";
 import type { RouterOutputs } from "~/trpc/react";
 import { authClient } from "~/server/better-auth/client";
@@ -12,7 +18,11 @@ type Org = RouterOutputs["application"]["listOrganizations"][number];
 
 const DRAFT_KEY = "seif-application-draft";
 
-function loadDraft(): { formData: FormData; budgetPath: string } | null {
+function loadDraft(): {
+  formData: FormData;
+  budgetPath: string;
+  phoneInput: string;
+} | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
@@ -20,20 +30,25 @@ function loadDraft(): { formData: FormData; budgetPath: string } | null {
     const parsed = JSON.parse(raw) as {
       formData: FormData;
       budgetPath?: string;
+      phoneInput?: string;
     };
     return {
       formData: parsed.formData ?? {},
       budgetPath: parsed.budgetPath ?? "",
+      phoneInput: parsed.phoneInput ?? "",
     };
   } catch {
     return null;
   }
 }
 
-function saveDraft(formData: FormData, budgetPath: string) {
+function saveDraft(formData: FormData, budgetPath: string, phoneInput: string) {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(DRAFT_KEY, JSON.stringify({ formData, budgetPath }));
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ formData, budgetPath, phoneInput }),
+    );
   } catch {
     // ignore
   }
@@ -305,10 +320,56 @@ function PhoneNumberField({
   required,
 }: {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (next: { displayValue: string; storedValue: string }) => void;
   required?: boolean;
 }) {
-  const { formatted, detectedCountry, callingCode } = getPhoneInputState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const nextSelectionRef = useRef<number | null>(null);
+  const { detectedCountry, callingCode, isValid } = getPhoneInputState(value);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    input.setCustomValidity(
+      value.length > 0 && !isValid ? "Enter a complete phone number." : "",
+    );
+  }, [isValid, value]);
+
+  useLayoutEffect(() => {
+    if (nextSelectionRef.current == null) return;
+
+    inputRef.current?.setSelectionRange(
+      nextSelectionRef.current,
+      nextSelectionRef.current,
+    );
+    nextSelectionRef.current = null;
+  }, [value]);
+
+  const handleChange = (nextValue: string, selectionStart: number | null) => {
+    const digitIndex = nextValue
+      .slice(0, selectionStart ?? nextValue.length)
+      .replace(/\D/g, "").length;
+    const nextState = getPhoneInputState(nextValue);
+
+    let digitsSeen = 0;
+    let nextSelection = nextState.formatted.length;
+    for (const [index, char] of [...nextState.formatted].entries()) {
+      if (/\d/.test(char)) {
+        digitsSeen += 1;
+      }
+      if (digitsSeen >= digitIndex) {
+        nextSelection = index + 1;
+        break;
+      }
+    }
+
+    nextSelectionRef.current = nextSelection;
+    onChange({
+      displayValue: nextState.formatted,
+      storedValue: nextState.e164 ?? "",
+    });
+  };
 
   return (
     <div>
@@ -320,13 +381,14 @@ function PhoneNumberField({
           <span className="font-medium">{callingCode}</span>
         </div>
         <input
+          ref={inputRef}
           type="tel"
           inputMode="tel"
           autoComplete="tel"
           className="min-w-0 flex-1 border-0 px-3 py-2 text-gray-900 outline-none placeholder:text-gray-500 focus:ring-0"
-          value={formatted}
+          value={value}
           onChange={(e) =>
-            onChange(getPhoneInputState(e.target.value).formatted)
+            handleChange(e.target.value, e.target.selectionStart)
           }
           placeholder="(519) 555-1234"
           required={required}
@@ -341,6 +403,7 @@ export function ApplicationForm() {
   const { data: session } = authClient.useSession();
   const [formData, setFormData] = useState<FormData>({});
   const [budgetPath, setBudgetPath] = useState<string>("");
+  const [phoneInput, setPhoneInput] = useState("");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [draftRestored, setDraftRestored] = useState(false);
 
@@ -352,15 +415,18 @@ export function ApplicationForm() {
   useEffect(() => {
     if (draftRestored) return;
     const draft = loadDraft();
-    if (draft && (Object.keys(draft.formData).length > 0 || draft.budgetPath)) {
-      const draftPhone = draft.formData.phone;
-      setFormData({
-        ...draft.formData,
-        ...(typeof draftPhone === "string"
-          ? { phone: getPhoneInputState(draftPhone).formatted }
-          : {}),
-      });
+    if (
+      draft &&
+      (Object.keys(draft.formData).length > 0 ||
+        draft.budgetPath ||
+        draft.phoneInput)
+    ) {
+      setFormData(draft.formData);
       setBudgetPath(draft.budgetPath);
+      setPhoneInput(
+        draft.phoneInput ||
+          getPhoneInputState((draft.formData.phone as string) ?? "").formatted,
+      );
     }
     setDraftRestored(true);
   }, [draftRestored]);
@@ -369,10 +435,10 @@ export function ApplicationForm() {
   useEffect(() => {
     if (!draftRestored) return;
     const t = setTimeout(() => {
-      saveDraft(formData, budgetPath);
+      saveDraft(formData, budgetPath, phoneInput);
     }, 500);
     return () => clearTimeout(t);
-  }, [formData, budgetPath, draftRestored]);
+  }, [formData, budgetPath, draftRestored, phoneInput]);
 
   const { data: organizations = [], isLoading: orgsLoading } =
     api.application.listOrganizations.useQuery();
@@ -397,7 +463,7 @@ export function ApplicationForm() {
     setSubmitError(null);
 
     if (!session?.user) {
-      saveDraft(formData, budgetPath);
+      saveDraft(formData, budgetPath, phoneInput);
       void authClient.signIn.social({
         provider: "microsoft",
         callbackURL: "/apply",
@@ -416,6 +482,10 @@ export function ApplicationForm() {
     }
     if (!Number.isFinite(amount) || amount <= 0) {
       setSubmitError("Please enter a valid amount requested.");
+      return;
+    }
+    if (typeof formData.phone !== "string" || formData.phone.length === 0) {
+      setSubmitError("Please enter a valid phone number.");
       return;
     }
     if (!budgetPath) {
@@ -494,8 +564,11 @@ export function ApplicationForm() {
           <div>
             <Label required>Phone Number</Label>
             <PhoneNumberField
-              value={(formData.phone as string) ?? ""}
-              onChange={(value) => update("phone", value)}
+              value={phoneInput}
+              onChange={({ displayValue, storedValue }) => {
+                setPhoneInput(displayValue);
+                update("phone", storedValue);
+              }}
               required
             />
           </div>

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -40,7 +40,7 @@ export function getPhoneInputState(
     formatted,
     detectedCountry,
     callingCode,
-    e164: isValid ? parsed.number : null,
+    e164: isValid && parsed ? parsed.number : null,
     isValid,
   };
 }

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -57,7 +57,7 @@ export function formatStoredPhoneNumber(
     return getPhoneInputState(rawValue, defaultCountry).formatted || rawValue;
   }
 
-  return rawValue.startsWith("+") || parsed.country !== defaultCountry
+  return parsed.country !== defaultCountry
     ? parsed.formatInternational()
     : parsed.formatNational();
 }

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,59 @@
+import {
+  AsYouType,
+  getCountryCallingCode,
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js/core";
+import metadata from "libphonenumber-js/metadata.min.json";
+
+export const DEFAULT_PHONE_COUNTRY: CountryCode = "CA";
+
+function normalizePhoneValue(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function getFlagEmoji(countryCode: string | null | undefined) {
+  const normalized = countryCode?.trim().toUpperCase();
+  if (!normalized || normalized.length !== 2) return "🇨🇦";
+
+  return String.fromCodePoint(
+    ...[...normalized].map((char) => 127397 + char.charCodeAt(0)),
+  );
+}
+
+export function getPhoneInputState(
+  value: unknown,
+  defaultCountry: CountryCode = DEFAULT_PHONE_COUNTRY,
+) {
+  const rawValue = normalizePhoneValue(value);
+  const formatter = new AsYouType(defaultCountry, metadata);
+  const formatted = formatter.input(rawValue);
+  const detectedCountry = formatter.getCountry() ?? defaultCountry;
+  const phoneNumber = formatter.getNumber();
+  const callingCode = phoneNumber?.countryCallingCode
+    ? `+${phoneNumber.countryCallingCode}`
+    : `+${getCountryCallingCode(detectedCountry, metadata)}`;
+
+  return {
+    formatted,
+    detectedCountry,
+    callingCode,
+  };
+}
+
+export function formatStoredPhoneNumber(
+  value: unknown,
+  defaultCountry: CountryCode = DEFAULT_PHONE_COUNTRY,
+) {
+  const rawValue = normalizePhoneValue(value);
+  if (!rawValue) return null;
+
+  const parsed = parsePhoneNumberFromString(rawValue, defaultCountry, metadata);
+  if (!parsed) {
+    return getPhoneInputState(rawValue, defaultCountry).formatted || rawValue;
+  }
+
+  return rawValue.startsWith("+") || parsed.country !== defaultCountry
+    ? parsed.formatInternational()
+    : parsed.formatNational();
+}

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -28,16 +28,20 @@ export function getPhoneInputState(
   const rawValue = normalizePhoneValue(value);
   const formatter = new AsYouType(defaultCountry, metadata);
   const formatted = formatter.input(rawValue);
-  const detectedCountry = formatter.getCountry() ?? defaultCountry;
-  const phoneNumber = formatter.getNumber();
-  const callingCode = phoneNumber?.countryCallingCode
-    ? `+${phoneNumber.countryCallingCode}`
+  const parsed = parsePhoneNumberFromString(rawValue, defaultCountry, metadata);
+  const detectedCountry =
+    formatter.getCountry() ?? parsed?.country ?? defaultCountry;
+  const callingCode = parsed?.countryCallingCode
+    ? `+${parsed.countryCallingCode}`
     : `+${getCountryCallingCode(detectedCountry, metadata)}`;
+  const isValid = parsed?.isValid() ?? false;
 
   return {
     formatted,
     detectedCountry,
     callingCode,
+    e164: isValid ? parsed.number : null,
+    isValid,
   };
 }
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -14,7 +14,7 @@ function normalizePhoneValue(value: unknown) {
 
 export function getFlagEmoji(countryCode: string | null | undefined) {
   const normalized = countryCode?.trim().toUpperCase();
-  if (!normalized || normalized.length !== 2) return "🇨🇦";
+  if (normalized?.length !== 2) return "🇨🇦";
 
   return String.fromCodePoint(
     ...[...normalized].map((char) => 127397 + char.charCodeAt(0)),


### PR DESCRIPTION
## Summary
- add `libphonenumber-js` and introduce shared phone utilities in `src/lib/phone.ts`
- replace free-text phone input in the SEIF application form with a country-aware, formatted phone field (flag/calling code + normalized formatting)
- normalize/restyle restored draft phone values so existing saved drafts render in the new format
- display formatted phone numbers on both applicant and admin application detail pages via `formatStoredPhoneNumber`
- include incidental formatting/ordering cleanup in touched files

## Testing
- Not run (automated tests not executed in this change set)
- Manually verify entering local and international numbers in the application form formats correctly as the user types
- Manually verify previously saved drafts with phone numbers load and display in normalized format
- Manually verify phone numbers render correctly on:
  - applicant view: `/applications/[id]`
  - admin view: `/admin/applications/[id]`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format SEIF application phone numbers with country-aware parsing
> - Adds [src/lib/phone.ts](https://github.com/csaguelph/seif/pull/9/files#diff-da2e667f4ecb512f586d41b343ffc91a80271a74d06f75baf880d542cada0a75) with utilities for as-you-type formatting, flag emoji rendering, E.164 extraction, and display formatting using `libphonenumber-js`, defaulting to Canada (`CA`).
> - Replaces the raw phone `<input>` in [application-form.tsx](https://github.com/csaguelph/seif/pull/9/files#diff-cdc517888693ffd27de262be40af558f588c43b1684ba0c5cbeaed00299bcabc) with a new `PhoneNumberField` component that shows a country flag, calling code badge, and formats input as the user types.
> - Stores E.164 format on submit and blocks submission if the phone number is invalid; draft persistence now also saves the formatted display string.
> - Both admin and applicant detail pages now display stored phone numbers in national format (for CA) or international format otherwise, falling back to an em dash when absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11de6d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds country-aware phone number formatting to the SEIF application form, replacing the free-text `<input type="tel">` with a `PhoneNumberField` component that shows a country flag/calling-code badge, formats input as-you-type via `libphonenumber-js`, and stores the normalised E.164 value in `formData.phone`. Display pages for both applicants and admins now render stored phone numbers through `formatStoredPhoneNumber`, which correctly shows national format for Canadian numbers and international format for others.

Key observations:
- The `PhoneNumberField` implementation addresses several issues from earlier review cycles: cursor restoration via `useLayoutEffect` + `nextSelectionRef`, `setCustomValidity` to enforce completeness, `showCodeInBadge` to avoid duplicating the calling code for international numbers, and the `parsed.country !== defaultCountry` condition in `formatStoredPhoneNumber` to correctly display Canadian E.164 values in national format.
- The split between `phoneInput` (display) and `formData.phone` (stored E.164 or `""`) is correct for new submissions; validation in `handleSubmit` uses `getPhoneInputState(formData.phone).isValid` as a server-side safety net.
- **Old draft migration gap**: when an existing draft that pre-dates this PR is restored, `draft.phoneInput` is absent so the display value is re-derived from `formData.phone`, but `formData.phone` itself is never promoted to E.164. The `handleSubmit` guard passes (national-format strings parse as valid), so the mutation can persist a non-E.164 phone value in the database. See the inline comment for a targeted fix.
- The `formatStoredPhoneNumber` fallback for unparseable values silently strips non-digit characters when the partially-extracted digit string is non-empty; the `|| rawValue` guard only fires for all-non-digit inputs. This is a minor edge-case noted inline.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for new submissions; the old-draft migration path can silently persist national-format phone strings instead of E.164 until those drafts expire.
- The core phone-input feature and display formatting are correct. The main outstanding concern is that pre-PR localStorage drafts bypass E.164 normalisation on restore and can submit national-format values. This is a data-quality issue (not a crash or security bug) but contradicts the PR's stated goal of canonical E.164 storage. All other previously-flagged issues (cursor management, double calling code, display format for Canadian E.164, validation gating) appear to have been addressed in this revision.
- src/components/seif/application-form.tsx (draft restore path, lines 416-430) and src/lib/phone.ts (formatStoredPhoneNumber fallback, lines 55-58)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/phone.ts | New utility module introducing country-aware phone parsing via libphonenumber-js. Core logic is sound; uses /core entry point with metadata.min.json for bundle efficiency. One edge case in the formatStoredPhoneNumber fallback path may silently strip non-digit characters from malformed stored values. |
| src/components/seif/application-form.tsx | Replaces plain tel input with PhoneNumberField component. Cursor management via useLayoutEffect and useEffect-based setCustomValidity are well-implemented. The split between phoneInput (display) and formData.phone (E.164) is correct for new entries, but old drafts with national-format phone values bypass E.164 normalisation on restore and submit in the pre-PR format. |
| src/app/admin/applications/[id]/page.tsx | Adds formatStoredPhoneNumber to the detail page and reformats Tailwind class ordering. No logic issues. |
| src/app/applications/[id]/page.tsx | Same pattern as admin page — adds readPhone helper using formatStoredPhoneNumber. No logic issues. |
| package.json | Adds libphonenumber-js ^1.12.40 as a runtime dependency and sorts existing entries. No issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types in PhoneNumberField] --> B[handleChange called\ne.target.value + selectionStart]
    B --> C[getPhoneInputState nextValue\nAsYouType formats digits]
    C --> D{isValid?}
    D -- Yes --> E[onChange\ndisplayValue = formatted\nstoredValue = e164]
    D -- No --> F[onChange\ndisplayValue = formatted\nstoredValue = empty string]
    E --> G[setPhoneInput displayValue\nupdate phone = e164]
    F --> H[setPhoneInput displayValue\nupdate phone = empty]
    G --> I[useLayoutEffect\nrestore cursor via nextSelectionRef]
    H --> I

    subgraph "Draft Save"
        G --> J[saveDraft formData budgetPath phoneInput]
    end

    subgraph "Draft Restore"
        K[loadDraft] --> L{draft.phoneInput set?}
        L -- Yes --> M[setPhoneInput draft.phoneInput]
        L -- No --> N[getPhoneInputState draft.formData.phone\nsetPhoneInput formatted]
        N --> O[⚠️ formData.phone stays\nin pre-PR national format]
    end

    subgraph "handleSubmit"
        P[getPhoneInputState formData.phone\n.isValid check] -- false --> Q[setSubmitError]
        P -- true --> R[create.mutate formData\nphone = E.164 or national format]
    end

    subgraph "Detail Pages"
        S[formatStoredPhoneNumber stored value] --> T{parsed?}
        T -- CA --> U[formatNational]
        T -- Other --> V[formatInternational]
        T -- null --> W[AsYouType fallback or rawValue]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/seif/application-form.tsx`, line 414-432 ([link](https://github.com/csaguelph/seif/blob/87f9fcc36759d741f5f84495562e7daeaf0f6b1a/src/components/seif/application-form.tsx#L414-L432)) 

   **Old drafts restore stale display-string to `formData.phone`, bypassing E.164**

   When a draft was saved before this PR, `draft.phoneInput` is `undefined` and `draft.formData.phone` is a display string like `"(519) 555-1234"`. The restore path calls `setFormData(draft.formData)`, so `formData.phone` ends up as that display string — not an E.164 value.

   `phoneInput` is correctly re-formatted via `getPhoneInputState(...).formatted`, but the stored `formData.phone` is never updated to match. Because `handleSubmit` only checks `formData.phone.length === 0`, a complete but non-E.164 phone (e.g. `"(519) 555-1234"`) passes the guard and gets submitted/stored in the old display format.

   Consider normalising `formData.phone` to E.164 during restore, for example:

   ```tsx
   const restoredInput =
     draft.phoneInput ||
     getPhoneInputState((draft.formData.phone as string) ?? "").formatted;
   const { e164 } = getPhoneInputState(restoredInput);
   setFormData({ ...draft.formData, phone: e164 ?? (draft.formData.phone as string) ?? "" });
   setBudgetPath(draft.budgetPath);
   setPhoneInput(restoredInput);
   ```

   This ensures that any draft — old or new — always restores `formData.phone` as the canonical E.164 value before the user submits.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/seif/application-form.tsx
   Line: 414-432

   Comment:
   **Old drafts restore stale display-string to `formData.phone`, bypassing E.164**

   When a draft was saved before this PR, `draft.phoneInput` is `undefined` and `draft.formData.phone` is a display string like `"(519) 555-1234"`. The restore path calls `setFormData(draft.formData)`, so `formData.phone` ends up as that display string — not an E.164 value.

   `phoneInput` is correctly re-formatted via `getPhoneInputState(...).formatted`, but the stored `formData.phone` is never updated to match. Because `handleSubmit` only checks `formData.phone.length === 0`, a complete but non-E.164 phone (e.g. `"(519) 555-1234"`) passes the guard and gets submitted/stored in the old display format.

   Consider normalising `formData.phone` to E.164 during restore, for example:

   ```tsx
   const restoredInput =
     draft.phoneInput ||
     getPhoneInputState((draft.formData.phone as string) ?? "").formatted;
   const { e164 } = getPhoneInputState(restoredInput);
   setFormData({ ...draft.formData, phone: e164 ?? (draft.formData.phone as string) ?? "" });
   setBudgetPath(draft.budgetPath);
   setPhoneInput(restoredInput);
   ```

   This ensures that any draft — old or new — always restores `formData.phone` as the canonical E.164 value before the user submits.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/phone.ts
Line: 55-58

Comment:
**Fallback silently drops non-digit characters from malformed values**

In the `parsed === null` branch, `getPhoneInputState(rawValue).formatted` is returned when truthy. Because `AsYouType` strips every non-digit (and non-`+`) character during processing, a malformed stored value such as `"abc123"` would have digits extracted and be displayed as `"123"` — the `|| rawValue` safety net only fires when `formatted` is the empty string (i.e. there are no digits at all).

For real-world data the values will all be either E.164 or national-format strings, so this won't trigger. But if you want to guarantee the raw value is always preserved when it can't be parsed, flip the order of the fallback:

```suggestion
    return rawValue || getPhoneInputState(rawValue, defaultCountry).formatted;
```

This shows the raw string first and falls back to the partially-formatted representation only when the stored value is empty.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/seif/application-form.tsx
Line: 416-430

Comment:
**Restored `formData.phone` not re-normalised to E.164 when draft `phoneInput` is missing**

When an old draft (saved before this PR) is restored, `draft.phoneInput` is `undefined`, so `phoneInput` is set to the display-formatted value derived from `draft.formData.phone`. However, `setFormData(draft.formData)` is called first, meaning `formData.phone` retains the original national-format string (e.g. `"(519) 555-1234"`) rather than an E.164 value.

Because `getPhoneInputState("(519) 555-1234").isValid` is `true`, the `handleSubmit` guard passes, and the mutation is called with `formData.phone = "(519) 555-1234"` instead of `"+15195551234"`.

For new drafts `draft.phoneInput` is populated so this path is exercised only during the migration window, but it can silently persist non-E.164 values in the database. A targeted re-normalisation on restore would avoid this:

```tsx
// After setFormData(draft.formData):
const restoredPhone = (draft.formData.phone as string) ?? "";
const restoredState = getPhoneInputState(restoredPhone);
if (restoredState.isValid && restoredState.e164) {
  update("phone", restoredState.e164);   // promote to E.164
}
setPhoneInput(draft.phoneInput || restoredState.formatted);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 11de6d7</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->